### PR TITLE
Add version option to envcloak command in CLI

### DIFF
--- a/envcloak/cli.py
+++ b/envcloak/cli.py
@@ -7,6 +7,7 @@ from envcloak.utils import add_to_gitignore
 
 
 @click.group()
+@click.version_option(prog_name="EnvCloak")
 def main():
     """
     EnvCloak: Securely manage encrypted environment variables.


### PR DESCRIPTION
Hi, 

This PR introduces the --version command to the envcloak CLI, as requested in Fixes #9 – Introduce --version command